### PR TITLE
Add getArchive function for external archive management

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,4 +9,16 @@ var defaultDir = path.join(process.cwd(), 'dats')
 var archiver = Archiver({dir: args.dir || defaultDir})
 var key = args._[0] || crypto.randomBytes(16).toString('hex')
 archiver.join(key)
-console.log(key)
+console.log('Created archiver server:', key)
+
+archiver.on('connection', function (key) {
+  console.log('New Connection on server:', key)
+})
+
+archiver.on('archive-replicating', function (key) {
+  console.log('Archive replication starting:', key)
+})
+
+archiver.on('archive-finished', function (key) {
+  console.log('Archive finished replicating:', key)
+})

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ function Archiver (options) {
   self.getArchive = options.getArchive || getArchive
 
   function getArchive(key, cb) {
-    var datDir = path.join(self.options.dir, datKey)
+    var datDir = path.join(self.options.dir, key)
     mkdirp.sync(datDir)
-    var dat = self.peers[datKey] = Dat({dir: datDir, discovery: false, key: datKey})
+    var dat = self.peers[key] = Dat({dir: datDir, discovery: false, key: key})
     dat.open(function (err) {
       if (err) return cb(err)
       console.log('dat ready')

--- a/index.js
+++ b/index.js
@@ -50,10 +50,10 @@ Archiver.prototype.join = function (key) {
       datKey = datKey.toString('hex')
       self.emit('key-received', datKey)
       self.getArchive(datKey, function (err, archive, cb) {
-        if (err) throw err
+        if (err) self.emit('error', err)
         self.emit('archive-replicating', datKey)
         pump(stream, archive.replicate(), stream, function (err) {
-          if (err) throw err
+          if (err) self.emit('error', err)
           self.emit('archive-finished', datKey)
           cb()
         })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/maxogden/dat-archiver#readme",
   "description": "",
   "dependencies": {
-    "dat-js": "^2.0.0",
+    "dat-js": "^3.3.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "peer-network": "^1.1.0",

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,87 @@
+# Dat Archiver
+
+Server for archiving files via Dat. Upload files with [dat-push](https://github.com/joehand/dat-push). Runs a [peer network](https://github.com/mafintosh/peer-network) server.
+
+## Installation
+
+```
+npm install -g dat-archiver
+```
+
+## Usage
+
+On a server run:
+
+```
+dat-archiver my-backup-server --dir=archive_directory
+```
+
+Creates a dat-archiver server with name, with the server key `my-backup-server`. If key is not set, a 16 digit string will be generated. Dats files are saved to the current directory or `--dir` option.
+
+On your local computer with Dat files:
+
+```
+dat-push my-backup-server --dir=directory_to_backup
+```
+
+This will push the files to your server over peer to peer networks.
+
+## API
+
+Dat archiver can run multiple archive servers to backup all archives to a single directory. See `cli.js` or [dat-publish](https://github.com/joehand/dat-publish) for an example.
+
+### `var archiver = Archiver(opts)`
+
+Create an archiver, options include:
+
+```js
+{
+  dir: 'dats', // directory to store dat archives. Subdirectories are created using archive keys as the name
+  getArchive: function (archiveKey, cb) {} // optional function to get archive on new dat-push connection. See example below.
+}
+```
+
+#### getArchive function
+
+The default getArchive function will create a new folder with the key name and prepare to download it with a `dat-push`.
+
+The `getArchive` function can be useful in modules that manage their own archives. The default function will download the dat via [dat-js](https://github.com/joehand/dat-js). 
+
+A custom `getArchive` function may look like this:
+
+```js
+function getArchive (datKey, cb) {
+  if (err) throw err
+  var dat = myDats[datKey]
+  if (!dat) return cb() // no archive found, you could create it here
+  dat.open(function () {
+    cb(null, dat.archive)
+  })
+}
+```
+
+### archiver.join(serverKey)
+
+Create and join a new peer-network server with name, `serverKey`. 
+
+### Events
+
+#### archiver.on('connection', serverKey)
+
+New connection on `serverKey`
+
+#### archiver.on('key-received', archiveKey)
+
+Key received from `dat-push`. Emitted immediately before `getArchive(key)` is called.
+
+#### archiver.on('archive-replicating', archiveKey)
+
+Archive replication starting for `archiveKey`.
+
+#### archiver.on('archive-finished', archiveKey)
+
+Archive replication finished for `archiveKey`.
+
+## License
+
+ISC


### PR DESCRIPTION
Adds the `getArchive` function, similar to hyperdrive-http. 

This allows other modules to manage their own archives. `dat-archiver` will call a lookup function with the key and callback:

``` js
function getArchive(archiveKey, cb) {
  var archive = // use key to get archive instance
  cb(null, archive)
}
```

PR also adds:
- Readme!
- Updated dat-js to 3.x.x. This API is a bit easier for external modules and allows for files to update between shares.
- added an event emitter and a few events to show when replication starts/ends and on connections.
